### PR TITLE
DOC-2103: Remove `dev` network and update local development guidance

### DIFF
--- a/docs/private-networks/get-started/install/run-docker-image.md
+++ b/docs/private-networks/get-started/install/run-docker-image.md
@@ -97,6 +97,12 @@ This happens when the IPv6 support in Docker is disabled while connecting to an 
 
 :::
 
+### Run a node for testing
+
+To run a local network for testing, use the
+[Developer Quickstart](../../tutorials/quickstart.md), which uses Docker Compose to generate a
+private network of Besu nodes.
+
 ## Stop Besu and clean up resources
 
 When done running nodes, you can shut down the node container without deleting resources or you can delete the container after stopping it. Run `docker container ls` and `docker volume ls` to get the container and volume names.

--- a/docs/private-networks/get-started/install/run-docker-image.md
+++ b/docs/private-networks/get-started/install/run-docker-image.md
@@ -97,14 +97,6 @@ This happens when the IPv6 support in Docker is disabled while connecting to an 
 
 :::
 
-### Run a node for testing
-
-To run a node for testing purposes with WebSocket enabled:
-
-```bash
-docker run -p 8546:8546 --mount type=bind,source=/<myvolume/besu/testnode>,target=/var/lib/besu hyperledger/besu:latest --rpc-ws-enabled --network=dev --data-path=/var/lib/besu
-```
-
 ## Stop Besu and clean up resources
 
 When done running nodes, you can shut down the node container without deleting resources or you can delete the container after stopping it. Run `docker container ls` and `docker volume ls` to get the container and volume names.

--- a/docs/private-networks/get-started/start-node.md
+++ b/docs/private-networks/get-started/start-node.md
@@ -22,8 +22,6 @@ To delete the local block data, delete the `database` directory in the `besu/bui
 
 To define a genesis configuration, create a [genesis file](../../public-networks/concepts/genesis-file.md) (for example, `genesis.json`) and specify the file using the [`--genesis-file`](../../public-networks/reference/options.md#genesis-file) option.
 
-When you specify [`--network=dev`](../../public-networks/reference/options.md#network), Besu uses the development mode genesis configuration with a fixed low difficulty. A node started with [`--network=dev`](../../public-networks/reference/options.md#network) has an empty bootnodes list by default.
-
 Predefined genesis configurations for named networks are in the [Besu source files](https://github.com/besu-eth/besu/tree/master/config/src/main/resources).
 
 ## Confirm node is running
@@ -56,35 +54,6 @@ If you started Besu with the [`--rpc-http-enabled`](../../public-networks/refere
   }
   ```
 
-## Run a node for testing
-
-To run a node for testing purposes:
-
-```bash
-besu --network=dev --rpc-http-cors-origins="all" --host-allowlist="*" --rpc-ws-enabled --rpc-http-enabled --data-path=/tmp/tmpDatdir
-```
-
-You can also use the following [configuration file](../../public-networks/how-to/configure-besu/index.md) on the command line to start a node with the same options as above:
-
-```toml
-network="dev"
-rpc-http-cors-origins=["all"]
-host-allowlist=["*"]
-rpc-ws-enabled=true
-rpc-http-enabled=true
-data-path="/tmp/tmpdata-path"
-```
-
-:::caution
-
-The following settings are a security risk in production environments:
-
-- Enabling the HTTP JSON-RPC service ([`--rpc-http-enabled`](../../public-networks/reference/options.md#rpc-http-enabled)) and setting [`--rpc-http-host`](../../public-networks/reference/options.md#rpc-http-host) to 0.0.0.0 exposes the RPC connection on your node to any remote connection.
-- Setting [`--host-allowlist`](../../public-networks/reference/options.md#host-allowlist) to `"*"` allows JSON-RPC API access from any host.
-- Setting [`--rpc-http-cors-origins`](../../public-networks/reference/options.md#rpc-http-cors-origins) to `"all"` or `"*"` allows cross-origin resource sharing (CORS) access from any domain.
-
-:::
-
 ## Run a node on a private network
 
 To run a node on your private network specifying a genesis file and data directory:
@@ -98,6 +67,16 @@ Where `<data-path>` is the path to the directory to save the chain data to. Ensu
 :::note
 
 You might need to set [`--tx-pool-limit-by-account-percentage`](../../public-networks/reference/options.md#tx-pool-limit-by-account-percentage) to 1. The default value is suitable for Mainnet, but may cause issues on private networks.
+
+:::
+
+:::caution
+
+The following settings are a security risk in production environments:
+
+- Enabling the HTTP JSON-RPC service ([`--rpc-http-enabled`](../../public-networks/reference/options.md#rpc-http-enabled)) and setting [`--rpc-http-host`](../../public-networks/reference/options.md#rpc-http-host) to 0.0.0.0 exposes the RPC connection on your node to any remote connection.
+- Setting [`--host-allowlist`](../../public-networks/reference/options.md#host-allowlist) to `"*"` allows JSON-RPC API access from any host.
+- Setting [`--rpc-http-cors-origins`](../../public-networks/reference/options.md#rpc-http-cors-origins) to `"all"` or `"*"` allows cross-origin resource sharing (CORS) access from any domain.
 
 :::
 

--- a/docs/private-networks/get-started/start-node.md
+++ b/docs/private-networks/get-started/start-node.md
@@ -64,6 +64,8 @@ besu --genesis-file=<path>/genesis.json --data-path=<data-path> --rpc-http-enabl
 
 Where `<data-path>` is the path to the directory to save the chain data to. Ensure you configure a peer discovery method, such as [bootnodes](../how-to/configure/bootnodes.md).
 
+If you don't have a network yet, use the [Developer Quickstart](../tutorials/quickstart.md) to generate one for testing, or follow [Create a QBFT network](../tutorials/qbft.md) to configure one yourself.
+
 :::note
 
 You might need to set [`--tx-pool-limit-by-account-percentage`](../../public-networks/reference/options.md#tx-pool-limit-by-account-percentage) to 1. The default value is suitable for Mainnet, but may cause issues on private networks.

--- a/docs/private-networks/how-to/monitor/opentelemetry.md
+++ b/docs/private-networks/how-to/monitor/opentelemetry.md
@@ -143,14 +143,17 @@ You can also install exporters that send system metrics to OpenTelemetry to moni
     
     </Tabs>
 
-2.  Start Besu with the [`--metrics-enabled`](../../../public-networks/reference/options.md#metrics-enabled) and [`--metrics-protocol=opentelemetry`](../../../public-networks/reference/options.md#metrics-protocol) options. For example, run the following command to start a single node:
+2.  Start Besu with the [`--metrics-enabled`](../../../public-networks/reference/options.md#metrics-enabled) and [`--metrics-protocol=opentelemetry`](../../../public-networks/reference/options.md#metrics-protocol) options.
+    Specify the [genesis file](../../../public-networks/reference/options.md#genesis-file) for your private network.
+    If you don't have a private network yet, create one using the [Developer Quickstart](../../tutorials/quickstart.md).
+    For example:
         
     <Tabs>
     
     <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
-    OTEL_EXPORTER_OTLP_ENDPOINT=https://<host>:<port> besu --network=dev --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled --metrics-protocol=opentelemetry
+    OTEL_EXPORTER_OTLP_ENDPOINT=https://<host>:<port> besu --genesis-file=<path>/genesis.json --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled --metrics-protocol=opentelemetry
     ```
 
     </TabItem>
@@ -158,7 +161,7 @@ You can also install exporters that send system metrics to OpenTelemetry to moni
     <TabItem value="Example" label="Example">
 
     ```bash
-    OTEL_EXPORTER_OTLP_ENDPOINT=https://localhost:4317 besu --network=dev --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled --metrics-protocol=opentelemetry
+    OTEL_EXPORTER_OTLP_ENDPOINT=https://localhost:4317 besu --genesis-file=/opt/besu/genesis.json --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled --metrics-protocol=opentelemetry
     ```
 
     </TabItem>

--- a/docs/private-networks/how-to/monitor/splunk.md
+++ b/docs/private-networks/how-to/monitor/splunk.md
@@ -69,7 +69,8 @@ If running [Besu as a Docker container](../../get-started/install/run-docker-ima
     3. Leave other fields with the default values.
     4. Save the `besu` index.
 
-3.  Run Besu. To start a Besu node running in development mode, run the following command:
+3.  Run Besu. To start a Besu node on your private network, run the following command.
+    If you don't have a private network yet, create one using the [Developer Quickstart](../../tutorials/quickstart.md):
 
     ```bash
     LOGGER=Splunk \
@@ -77,7 +78,7 @@ If running [Besu as a Docker container](../../get-started/install/run-docker-ima
     SPLUNK_TOKEN=11111111-1111-1111-1111-1111111111113 \
     SPLUNK_SKIPTLSVERIFY=true \
     besu \
-    --network=dev \
+    --genesis-file=<path>/genesis.json \
     --logging=trace
     ```
 

--- a/docs/private-networks/reference/accounts-for-testing.md
+++ b/docs/private-networks/reference/accounts-for-testing.md
@@ -8,13 +8,12 @@ import TestAccounts from '../../global/test_accounts.md';
 
 # Accounts for testing
 
-You can use existing accounts for testing by including them in the genesis file for a private network. Besu also provides predefined accounts for use in development mode.
+You can use existing accounts for testing by including them in the genesis file for a private network. Besu provides predefined test accounts in its `dev.json` genesis file.
 
-## Development mode
+## Predefined test accounts
 
-When you start Besu with the [`--network=dev`](../../public-networks/reference/options.md#network) command line option, Besu uses the `dev.json` genesis file by default.
-
-The `dev.json` genesis file defines the following accounts used for testing.
+Besu's `dev.json` genesis file defines the following test accounts.
+To use them, copy the account entries into the `alloc` section of the genesis file for your test network.
 
 <TestAccounts />
 

--- a/docs/public-networks/get-started/install/run-docker-image.md
+++ b/docs/public-networks/get-started/install/run-docker-image.md
@@ -100,14 +100,6 @@ This happens when the IPv6 support in Docker is disabled while connecting to an 
 
 :::
 
-### Run a node for testing
-  
-To run a node that mines blocks at a rate suitable for testing purposes with WebSocket enabled:
-
-```bash
-docker run -p 8546:8546 --mount type=bind,source=/<myvolume/besu/testnode>,target=/var/lib/besu hyperledger/besu:latest --rpc-ws-enabled --network=dev --data-path=/var/lib/besu
-```
-
 ### Run a node on Sepolia testnet
 
 To run a node on Sepolia:

--- a/docs/public-networks/get-started/install/run-docker-image.md
+++ b/docs/public-networks/get-started/install/run-docker-image.md
@@ -100,6 +100,12 @@ This happens when the IPv6 support in Docker is disabled while connecting to an 
 
 :::
 
+### Run a node for testing
+
+Besu doesn't provide a built-in development network. For local development options, including
+Ephemery and Kurtosis, see
+[Run a node for local development](../start-node.md#run-a-node-for-local-development).
+
 ### Run a node on Sepolia testnet
 
 To run a node on Sepolia:

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -27,8 +27,6 @@ To delete the local block data, delete the `database` directory in the `besu/bui
 
 Besu specifies the genesis configuration, and sets the network ID and bootnodes when connecting to [ETH testnets](#run-a-node-on-an-ethereum-testnet), and [Mainnet](#run-a-node-on-ethereum-mainnet).
 
-When you specify [`--network=dev`](../reference/options.md#network), Besu uses the development network genesis configuration, which is intended for local development and testing. A node started with [`--network=dev`](../reference/options.md#network) has an empty bootnodes list by default.
-
 The genesis files defining the genesis configurations are in the [Besu source files](https://github.com/besu-eth/besu/tree/master/config/src/main/resources).
 
 To define a genesis configuration, create a genesis file (for example, `genesis.json`) and specify the file using the [`--genesis-file`](../reference/options.md#genesis-file) option.
@@ -37,7 +35,7 @@ To define a genesis configuration, create a genesis file (for example, `genesis.
 
 By default, Besu syncs to the current state of the blockchain using [snap sync](../concepts/node-sync.md#snap-synchronization) in:
 
-- Networks specified using [`--network`](../reference/options.md#network) except for the `dev` development network.
+- Networks specified using [`--network`](../reference/options.md#network).
 - Ethereum Mainnet.
 
 We recommend using [snap sync](../concepts/node-sync.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/options.md#sync-mode).

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -102,6 +102,20 @@ besu --rpc-http-enabled
 
 See the [guide on connecting to Mainnet](connect/mainnet.md) for more information.
 
+## Run a node for local development
+
+Besu doesn't provide a built-in development network. Use one of the following instead:
+
+- [Ephemery](https://github.com/ephemery-testnet/ephemery-resources) is a public testnet that resets
+  periodically. Start Besu with `--network=ephemery` and pair it with a consensus client, as
+  described in [Run Besu and Teku on a testnet](../tutorials/besu-teku-testnet.md).
+- [Kurtosis](https://github.com/ethpandaops/ethereum-package) runs a self-contained network of
+  execution and consensus clients in Docker.
+
+To run an isolated network that you control, define your own
+[genesis file](../reference/options.md#genesis-file) and start a private network. The
+[Developer Quickstart](/private-networks/tutorials/quickstart) generates one for you.
+
 ## Confirm node is running
 
 If you started Besu with the [`--rpc-http-enabled`](../reference/options.md#rpc-http-enabled) option, use [cURL](https://curl.haxx.se/) to call [JSON-RPC API methods](../reference/api/index.md) to confirm the node is running.

--- a/docs/public-networks/how-to/monitor/metrics.md
+++ b/docs/public-networks/how-to/monitor/metrics.md
@@ -88,18 +88,26 @@ To configure Prometheus and run with Besu:
     <TabItem value="Syntax">
 
     ```bash
-    besu --network=dev --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled
+    besu --network=ephemery --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled
     ```
 
     </TabItem>
     <TabItem value="Example">
 
     ```bash
-    besu --network=dev --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled
+    besu --network=ephemery --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-enabled
     ```
 
     </TabItem>
     </Tabs>
+
+    :::note
+
+    Ephemery is a public testnet, so Besu needs a
+    [consensus client](../../concepts/node-clients.md#consensus-clients) to sync.
+    See [Run Besu and Teku on a testnet](../../tutorials/besu-teku-testnet.md).
+
+    :::
 
     To specify the host and port on which Prometheus accesses Besu, use the
     [`--metrics-host`](../../reference/options.md#metrics-host) and
@@ -162,14 +170,14 @@ To configure Prometheus and run with Besu pushing to a push gateway:
     <TabItem value="Syntax">
 
     ```bash
-    besu --network=dev --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-push-enabled --metrics-push-port=9091 --metrics-push-host=127.0.0.1
+    besu --network=ephemery --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-push-enabled --metrics-push-port=9091 --metrics-push-host=127.0.0.1
     ```
 
     </TabItem>
     <TabItem value="Example">
 
     ```bash
-    besu --network=dev --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-push-enabled --metrics-push-port=9091 --metrics-push-host=127.0.0.1
+    besu --network=ephemery --rpc-http-cors-origins="all" --rpc-http-enabled --metrics-push-enabled --metrics-push-port=9091 --metrics-push-host=127.0.0.1
     ```
 
     </TabItem>

--- a/docs/public-networks/reference/options.md
+++ b/docs/public-networks/reference/options.md
@@ -489,8 +489,8 @@ To use discovery v5 bootnodes, set the early access option `--Xv5-discovery-enab
 :::
 
 When connecting to Mainnet or public testnets, the default is a predefined list of bootnodes.
-In private networks defined using [`--genesis-file`](#genesis-file) or when using
-[`--network=dev`](#network), the default is an empty list of bootnodes.
+In private networks defined using [`--genesis-file`](#genesis-file), the default is an empty list
+of bootnodes.
 
 ---
 
@@ -2829,7 +2829,6 @@ Possible values include the following:
 | `mainnet`  | ETH   | Production  | [`SNAP`](#sync-mode) | PoS network       | The main [Ethereum network](https://ethereum.org/en/developers/docs/networks/) |
 | `hoodi`    | ETH   | Test        | [`SNAP`](#sync-mode) | PoS network       | Multi-client Ethereum testnet [Hoodi](https://hoodi.ethpandaops.io/)                    |
 | `sepolia`  | ETH   | Test        | [`SNAP`](#sync-mode) | PoS network       | Multi-client Ethereum testnet [Sepolia](https://sepolia.dev)                            |
-| `dev`      | ETH   | Development | [`FULL`](#sync-mode) | Dev mode          | Local development network for testing                                          |
 | `ephemery` | ETH   | Test        | [`SNAP`](#sync-mode) | PoS network       | Multi-client Ethereum testnet [Ephemery](https://ephemery.dev)  
 | `linea_mainnet`  | Linea   | Production        | [`SNAP`](#sync-mode) | Sequencer-based (zkEVM rollup)       | The main [Linea network](https://docs.linea.build/get-started/build/network-info)                            |
 | `linea_sepolia`  | Linea   | Test        | [`SNAP`](#sync-mode) | Sequencer-based (zkEVM rollup)      | Linea [Sepolia testnet](https://docs.linea.build/get-started/build/network-info/)                            |
@@ -2844,9 +2843,19 @@ Values are case-insensitive, so either `mainnet` or `MAINNET` works.
 
 :::info
 
-- You can't use the `--network` and [`--genesis-file`](#genesis-file) options at the same time.
+You can't use the `--network` and [`--genesis-file`](#genesis-file) options at the same time.
 
-- The following networks and testnets are deprecated: ETC (Ethereum Classic) and Mordor.
+:::
+
+:::warning Removed networks
+
+Besu no longer supports the `dev`, ETC (Ethereum Classic), and Mordor networks.
+
+Specifying `--network=dev` prevents Besu from starting.
+Proof of work mining has been removed, so the development network can't produce blocks.
+For local development, use Ephemery (`--network=ephemery`) with a
+[consensus client](../concepts/node-clients.md#consensus-clients), or use
+[Kurtosis](https://github.com/ethpandaops/ethereum-package).
 
 :::
 
@@ -6121,7 +6130,7 @@ sync-mode="SNAP"
 The synchronization mode. Use `SNAP` for [snap sync](../concepts/node-sync.md#snap-synchronization) and `FULL` for [full sync](../concepts/node-sync.md#full-synchronization).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
-- The default is `SNAP` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `SNAP` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).
+- The default is `SNAP` when using the [`--network`](#network) option with named networks. `SNAP` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).
 
 :::warning Checkpoint sync
 


### PR DESCRIPTION
**Do not merge this until confirmed in the Besu release. Post `26.8.0`.**

## Description

Besu removed `--network=dev` in [besu-eth/besu#10836](https://github.com/besu-eth/besu/pull/10836).
The flag isn't merely deprecated: Besu logs a framed warning and then aborts, so every
`--network=dev` example in the docs was a command that fails at startup. The dev network relied on
`ethash.fixeddifficulty` and proof of work mining, which was removed earlier, so it can no longer
produce blocks. The same PR also deleted the `dev` profile, which these docs never listed.

### Reference (`options.md`)

- Removed the `dev` row from the `--network` table.
- Added a "Removed networks" warning mirroring the CLI output, pointing to Ephemery and Kurtosis.
- Corrected the ETC/Mordor note: support was removed in besu#9671, not deprecated.
- Dropped the `--network=dev` exceptions from `--bootnodes` and `--sync-mode`, which makes the
  `SNAP` default unconditional for all remaining named networks.

### Examples that no longer start

- Public `metrics.md` uses `--network=ephemery`, with a note that Ephemery needs a consensus client.
- Private `opentelemetry.md` and `splunk.md` use `--genesis-file` instead, since readers of
  private-networks pages already run their own network, with links to the Developer Quickstart.
- Removed the "run a node for testing" commands from both Docker pages and private `start-node.md`.
  Their premise was a single command that produces blocks, and no single command replaces that. The
  security `:::caution` from `start-node.md` is kept, relocated under "Run a node on a private
  network".

### Replacement guidance for local development

Removing those sections would otherwise leave readers without an answer for how to run a node
locally, so the supported alternatives are documented instead:

- Public `start-node.md` gains a "Run a node for local development" section covering Ephemery
  (with a consensus client), Kurtosis, and defining your own genesis file for a private network.
  Public networks previously had no local-development guidance anywhere.
- Both Docker pages keep the `Run a node for testing` heading, now as a short signpost to the
  relevant page. Keeping the original wording preserves the `#run-a-node-for-testing` anchor that
  external links and search results point at.
- Private `start-node.md` points readers without a network to the Developer Quickstart or the QBFT
  tutorial.

### Other updates

- Removed the dev-mode genesis paragraphs from both `start-node.md` pages.
- Reframed "Development mode" in `accounts-for-testing.md` as "Predefined test accounts". The
  accounts still ship in `dev.json` and remain valid as a template for your own genesis file.

## Related issue(s)

Fixes #2103

## Preview

- https://besu-docs-git-fork-bgravenorst-doc-2103-hyperledger.vercel.app/public-networks/reference/options#network
- https://besu-docs-git-fork-bgravenorst-doc-2103-hyperledger.vercel.app/public-networks/get-started/start-node#run-a-node-for-local-development
- https://besu-docs-git-fork-bgravenorst-doc-2103-hyperledger.vercel.app/public-networks/get-started/install/run-docker-image#run-a-node-for-testing
- https://besu-docs-git-fork-bgravenorst-doc-2103-hyperledger.vercel.app/private-networks/get-started/start-node
