### PR TITLE
Sync update

### DIFF
--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -122,8 +122,13 @@ blockchain download.
 
 While the world state syncs, Besu downloads and imports the blockchain in the background.
 The blockchain download time depends on CPU, the network, Besu's peers, and disk speed.
-The blockchain download generally takes longer than the world state sync. Besu must catch up to the 
-current chain head and sync the world state to participate on Mainnet.
+The blockchain download is usually faster than the world state sync.
+The world state syncs against a pivot block, a safe block near the chain head that the
+[consensus client](node-clients.md#execution-and-consensus-clients) announces.
+After the blockchain download catches up to the current pivot block, it pauses until the world
+state sync moves to a new pivot block or finishes.
+The world state sync therefore determines the overall sync time.
+Besu must catch up to the current chain head and sync the world state to participate on Mainnet.
 
 The following table shows estimates for each sync mode on Mainnet.
 All times are hardware dependent.

--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -91,6 +91,10 @@ You can restart Besu during a snap sync in case of hardware or software problems
 from the last valid world state and continues to download blocks starting from the last downloaded
 block.
 
+If the chain stops finalizing for an extended period and more than one fork is being built on, you
+can anchor snap sync to a checkpoint block to
+[sync to a specific fork](../how-to/sync-to-a-specific-fork.md).
+
 See [how to read the Besu metrics charts](../how-to/monitor/understand-metrics.md) when using
 snap sync.
 

--- a/docs/public-networks/how-to/sync-to-a-specific-fork.md
+++ b/docs/public-networks/how-to/sync-to-a-specific-fork.md
@@ -7,38 +7,41 @@ keywords: [checkpoint, fork, non-finality, snap sync]
 
 If the chain stops finalizing for an extended period and more than one fork is being built on,
 you can pin Besu to the fork you consider correct.
-You anchor [snap sync](../concepts/node-sync.md#snap-synchronization) to a checkpoint block on that
+Anchor [snap sync](../concepts/node-sync.md#snap-synchronization) to a checkpoint block on that
 fork, and reject any peer that doesn't have that block.
-
-:::warning
-
-Besu disconnects from every peer that doesn't have the block you specify.
-If the block hash and number don't match a block that exists, Besu finds no peers
-and doesn't sync.
-Confirm against a source you trust that the block exists and is on the fork you
-want to follow before you start the node.
-
-:::
 
 ## Prerequisites
 
-- A new installation with an empty data directory.
-  These options apply to a fresh sync only, not to a node that has already synced.
-- [Snap sync](../concepts/node-sync.md#snap-synchronization).
-  Snap sync is the default for all named networks, so you don't need to set
-  [`--sync-mode=SNAP`](../reference/options.md#sync-mode) unless your configuration selects a
-  different sync mode.
-- The hash and number of a block that you have verified is on the fork you want to follow.
+Ensure you have a new Besu installation with an empty data directory.
+To sync to a specific fork, you cannot use a node that has already synced.
+
+## Steps
+
+### 1. Get your checkpoint block information
+
+Choose the fork you want to follow, and choose a block on that fork to anchor snap sync to.
+Verify the following information about the checkpoint block:
+
+- **The block hash and number.**
   Query a node that is already following the intended fork, or use a block explorer that reports
   that fork.
-- The total difficulty at that block.
-  Every Proof of Stake (PoS) block has a difficulty of `0`, so the total difficulty stopped
-  increasing at [the merge](https://ethereum.org/en/roadmap/merge/) and is identical for every
-  block since.
-  On Mainnet, that value is `0xC70D815D562D3CFA955`, the total difficulty at block 15537394, the
-  first PoS block.
 
-## Configure the node
+  :::warning
+  Besu disconnects from every peer that doesn't have the block you specify.
+  If the block hash and number don't match a block that exists, Besu finds no peers
+  and doesn't sync.
+  Confirm against a source you trust that the block exists and is on the fork you
+  want to follow before you start the node.
+  :::
+
+- **The total difficulty.**
+  Every proof-of-stake (PoS) block has a difficulty of `0`, so the total difficulty stopped
+  increasing at [The Merge](https://ethereum.org/en/roadmap/merge/) and is identical for every
+  block since.
+  On Mainnet, that value is `0xC70D815D562D3CFA955` (the total difficulty at block 15537394, the
+  first PoS block).
+
+### 2. Start Besu with a new configuration
 
 Start Besu with the following options:
 
@@ -64,6 +67,13 @@ In the command:
 - [`--required-block`](../reference/options.md#required-block) rejects any peer that doesn't have
   the specified hash at the specified block number.
   Use the same block as the checkpoint so that Besu only peers with nodes on your chosen fork.
+
+:::note
+Ensure you are using [snap sync](../concepts/node-sync.md#snap-synchronization).
+Snap sync is the default for all named networks, so you don't need to set
+[`--sync-mode=SNAP`](../reference/options.md#sync-mode) unless your configuration selects a
+different sync mode.
+:::
 
 Because `--required-block` filters out peers on other forks, expect a smaller peer count than
 usual, and a longer time to find enough peers to sync.

--- a/docs/public-networks/how-to/sync-to-a-specific-fork.md
+++ b/docs/public-networks/how-to/sync-to-a-specific-fork.md
@@ -1,0 +1,71 @@
+---
+title: Sync to a specific fork
+sidebar_position: 9
+description: Configure Besu to sync to a chosen fork during an extended period of non-finality.
+keywords: [checkpoint, fork, non-finality, snap sync]
+---
+
+If the chain stops finalizing for an extended period and more than one fork is being built on,
+you can pin Besu to the fork you consider correct.
+You anchor [snap sync](../concepts/node-sync.md#snap-synchronization) to a checkpoint block on that
+fork, and reject any peer that doesn't have that block.
+
+:::warning
+
+Besu disconnects from every peer that doesn't have the block you specify.
+If the block hash and number don't match a block that exists, Besu finds no peers
+and doesn't sync.
+Confirm against a source you trust that the block exists and is on the fork you
+want to follow before you start the node.
+
+:::
+
+## Prerequisites
+
+- A new installation with an empty data directory.
+  These options apply to a fresh sync only, not to a node that has already synced.
+- [Snap sync](../concepts/node-sync.md#snap-synchronization).
+  Snap sync is the default for all named networks, so you don't need to set
+  [`--sync-mode=SNAP`](../reference/options.md#sync-mode) unless your configuration selects a
+  different sync mode.
+- The hash and number of a block that you have verified is on the fork you want to follow.
+  Query a node that is already following the intended fork, or use a block explorer that reports
+  that fork.
+- The total difficulty at that block.
+  Every Proof of Stake (PoS) block has a difficulty of `0`, so the total difficulty stopped
+  increasing at [the merge](https://ethereum.org/en/roadmap/merge/) and is identical for every
+  block since.
+  On Mainnet, that value is `0xC70D815D562D3CFA955`, the total difficulty at block 15537394, the
+  first PoS block.
+
+## Configure the node
+
+Start Besu with the following options:
+
+```bash
+besu \
+  --checkpoint=<BLOCK_HASH>:<BLOCK_NUMBER>:<TOTAL_DIFFICULTY> \
+  --snapsync-synchronizer-skip-pre-checkpoint-headers-enabled=true \
+  --required-block=<BLOCK_NUMBER>=<BLOCK_HASH>
+```
+
+In the command:
+
+- [`--checkpoint`](../reference/options.md#checkpoint) anchors sync to your chosen block, in the
+  format `<blockHash>:<blockNumber>:<totalDifficulty>`.
+  This overrides any
+  [checkpoint configured in the genesis file](../reference/genesis-items.md#checkpoint-configuration).
+- [`--snapsync-synchronizer-skip-pre-checkpoint-headers-enabled`](../reference/options.md#snapsync-synchronizer-skip-pre-checkpoint-headers-enabled)
+  stops the header download at the checkpoint instead of continuing back to the genesis block.
+  The default is `false`, so you must set it explicitly.
+  Below the checkpoint, a peer can serve headers that aren't on the fork you want, and Besu
+  restarts the header download and retries for as long as it takes.
+  Stopping at the checkpoint gives the header download a better chance of completing.
+- [`--required-block`](../reference/options.md#required-block) rejects any peer that doesn't have
+  the specified hash at the specified block number.
+  Use the same block as the checkpoint so that Besu only peers with nodes on your chosen fork.
+
+Because `--required-block` filters out peers on other forks, expect a smaller peer count than
+usual, and a longer time to find enough peers to sync.
+
+After the chain finalizes again, remove these options and restart the node to peer normally.

--- a/docs/public-networks/reference/options.md
+++ b/docs/public-networks/reference/options.md
@@ -639,9 +639,15 @@ A trusted checkpoint to anchor sync to, in the format `<blockHash>:<blockNumber>
 - `blockHash` must be a 32-byte hex string.
 - `blockNumber` must be a non-negative integer.
 - `totalDifficulty` can be a decimal or `0x`-prefixed hex value.
+  Total difficulty stopped increasing at [the merge](https://ethereum.org/en/roadmap/merge/), so
+  every post-merge block on a network has the same value.
+  On Mainnet, that value is `0xC70D815D562D3CFA955` (`58750003716598352816469`).
 
 This option is only used by [snap sync](../concepts/node-sync.md#snap-synchronization).
 It's ignored when [`--sync-mode`](#sync-mode) is set to `FULL`.
+
+You can use this option to [sync to a specific fork](../how-to/sync-to-a-specific-fork.md) during an
+extended period of non-finality.
 
 ---
 
@@ -3692,6 +3698,9 @@ required-block=["6485846=0x43f0cd1e5b1f9c4d5cda26c240b59ee4f1b510d0a185aa8fd476d
 
 Requires a peer with the specified block number to have the specified hash when connecting, or Besu rejects that peer.
 
+You can use this option to [sync to a specific fork](../how-to/sync-to-a-specific-fork.md) during an
+extended period of non-finality.
+
 ---
 
 ## `revert-reason-enabled`
@@ -5889,6 +5898,63 @@ download pre-merge Proof of Work (PoW) block bodies or transaction receipts, and
 headers.
 To retain full pre-merge block history, use [full sync](../concepts/node-sync.md#full-synchronization),
 or sync using a genesis file that doesn't specify a checkpoint.
+
+:::
+
+To skip downloading pre-checkpoint headers entirely, use
+[`--snapsync-synchronizer-skip-pre-checkpoint-headers-enabled`](#snapsync-synchronizer-skip-pre-checkpoint-headers-enabled).
+
+---
+
+## `snapsync-synchronizer-skip-pre-checkpoint-headers-enabled`
+
+<Tabs>
+
+<TabItem value="Command line example">
+
+```bash
+--snapsync-synchronizer-skip-pre-checkpoint-headers-enabled=true
+```
+
+</TabItem>
+
+<TabItem value="Environment variable example">
+
+```bash
+BESU_SNAPSYNC_SYNCHRONIZER_SKIP_PRE_CHECKPOINT_HEADERS_ENABLED=true
+```
+
+</TabItem>
+
+<TabItem value="Config file example">
+
+```bash
+snapsync-synchronizer-skip-pre-checkpoint-headers-enabled=true
+```
+
+</TabItem>
+
+</Tabs>
+
+During [snap sync](../concepts/node-sync.md#snap-synchronization), downloads block headers back to
+the trusted checkpoint only, instead of all the way to the genesis block.
+Besu doesn't store headers earlier than the checkpoint.
+
+This option requires a checkpoint, set using either [`--checkpoint`](#checkpoint) or a
+[checkpoint section in the genesis file](genesis-items.md#checkpoint-configuration).
+Besu doesn't start if you enable this option without a checkpoint.
+
+Use this option with [`--required-block`](#required-block) to
+[sync to a specific fork](../how-to/sync-to-a-specific-fork.md) during an extended period of
+non-finality.
+
+The default is `false`.
+
+:::note
+
+Don't confuse this option with the deprecated
+[`--snapsync-synchronizer-pre-checkpoint-headers-only-enabled`](#snapsync-synchronizer-pre-checkpoint-headers-only-enabled),
+which has no effect.
 
 :::
 


### PR DESCRIPTION
## Description

Documents how to sync Besu to a chosen fork during an extended period of non-finality, and                                                               
  corrects the sync-time explanation on the node synchronization page.                                                                                     
                                                                                                                                                           
  Adds a how-to page, `Sync to a specific fork`, covering `--checkpoint`,                                                                                  
  `--snapsync-synchronizer-skip-pre-checkpoint-headers-enabled`, and `--required-block`, with a                                                            
  warning that an unverified block hash and number leaves the node without peers or on the wrong                                                           
  fork.                                                                                                                                                    
                                                                                                                                                           
  Adds the missing reference entry for                                                                                                                     
  `--snapsync-synchronizer-skip-pre-checkpoint-headers-enabled` (new in Besu 26.8.1,                                                                       
  besu-eth/besu#10958), which was undocumented and is easily confused with the deprecated no-op                                                            
  `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled`; the two entries now cross-link.                                                           
  Documents that post-merge total difficulty is fixed under `--checkpoint`.                                                                                
                                                                                                                                                           
  Corrects `Sync times`, which claimed the blockchain download generally takes longer than the                                                             
  world state sync. The blockchain download is usually faster and pauses once it catches up to the                                                         
  current pivot block, so the world state sync determines the overall sync time. Also defines                                                              
  "pivot block" on first use as the safe block announced by the consensus client. 

fixes #2126 
