### PR TITLE
ci: point GitHub Actions at Consensys-Incorporated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        uses: ConsenSys/github-actions/docs-build@main
+        uses: Consensys-Incorporated/github-actions/docs-build@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: LinkCheck
-        uses: ConsenSys/github-actions/docs-link-check@main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@main
         with:
           FILE_EXTENSION: ${{ matrix.file-extensions }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Lint
-        uses: ConsenSys/github-actions/docs-lint-all@main
+        uses: Consensys-Incorporated/github-actions/docs-lint-all@main


### PR DESCRIPTION
## Summary
- Retarget reusable docs GitHub Actions from `Consensys/github-actions` (now 404) to [`Consensys-Incorporated/github-actions`](https://github.com/Consensys-Incorporated/github-actions).
- Keeps existing commit SHAs / `@main` pins; only the org path changes.

## Test plan
- [ ] Confirm CI jobs that previously failed with "Unable to resolve action Consensys/github-actions/..." now start.
- [ ] Confirm lint/build/link-check workflows still run against this PR.